### PR TITLE
Detect CloudFlare's flexible SSL implementation.

### DIFF
--- a/patrol/services/PatrolService.php
+++ b/patrol/services/PatrolService.php
@@ -252,11 +252,7 @@ class PatrolService extends BaseApplicationComponent
 	/**
 	 * Determines whether we're already secured, even if on CloudFlare Flexible SSL
 	 *
-	 * @param array|string|null $values
-	 * @param callable          $filter
-	 * @param bool              $preserveKeys
-	 *
-	 * @return array
+	 * @return bool
 	 */
 	protected function isSecureConnection()
 	{

--- a/patrol/services/PatrolService.php
+++ b/patrol/services/PatrolService.php
@@ -260,7 +260,7 @@ class PatrolService extends BaseApplicationComponent
 
 		if (isset($_SERVER['HTTP_CF_VISITOR']))
 		{
-			if (strpos($_SERVER['HTTP_CF_VISITOR'], 'https'))
+			if (strpos($_SERVER['HTTP_CF_VISITOR'], 'https') !== false)
 				$isSecure = true; // CloudFlare confirms the original https request
 		}
 

--- a/patrol/services/PatrolService.php
+++ b/patrol/services/PatrolService.php
@@ -44,7 +44,7 @@ class PatrolService extends BaseApplicationComponent
 		{
 			$requestedUrl      = craft()->request->getUrl();
 			$restrictedAreas   = $settings['restrictedAreas'];
-			$securedConnection = craft()->request->isSecureConnection();
+			$securedConnection = $this->isSecureConnection();
 
 			// Forcing SSL if no restricted areas are defined, equivalent to strict mode.
 			if (empty($restrictedAreas))
@@ -247,6 +247,28 @@ class PatrolService extends BaseApplicationComponent
 				return true;
 			}
 		);
+	}
+
+	/**
+	 * Determines whether we're already secured, even if on CloudFlare Flexible SSL
+	 *
+	 * @param array|string|null $values
+	 * @param callable          $filter
+	 * @param bool              $preserveKeys
+	 *
+	 * @return array
+	 */
+	protected function isSecureConnection()
+	{
+		$isSecure = craft()->request->isSecureConnection();
+
+		if (isset($_SERVER['HTTP_CF_VISITOR']))
+		{
+			if (strpos($_SERVER['HTTP_CF_VISITOR'], 'https'))
+				$isSecure = true; // CloudFlare confirms the original https request
+		}
+
+		return $isSecure;
 	}
 
 	/**


### PR DESCRIPTION
This fixes a potential redirect loop that'd be created for a site using CloudFlare's flexible SSL by checking the `HTTP_CF_VISITOR` header for an `https` scheme. 

CloudFlare can make an _http_ request to the server that's delivered to the end user as _https_, leaving Craft's `isSecureConnection()` to return false and send Patrol into an endless loop trying to secure an already-secure URL.

A broader solution could be a custom Craft constant for `HTTP_X_FORWARDED_PROTO`, but this patch at least solves the problem as it relates to Patrol and CloudFlare.