### PR TITLE
Changing the SSL redirects to be 301's instead of 302's

### DIFF
--- a/services/PatrolService.php
+++ b/services/PatrolService.php
@@ -212,7 +212,7 @@ class PatrolService extends BaseApplicationComponent
      */
     protected function forceSsl()
     {
-        craft()->request->redirect('https://'.craft()->request->getServerName().craft()->request->getUrl());
+        craft()->request->redirect('https://'.craft()->request->getServerName().craft()->request->getUrl(), true, 301);
     }
 
     /**
@@ -220,7 +220,7 @@ class PatrolService extends BaseApplicationComponent
      */
     protected function revertSsl()
     {
-        craft()->request->redirect('http://'.craft()->request->getServerName().craft()->request->getUrl());
+        craft()->request->redirect('http://'.craft()->request->getServerName().craft()->request->getUrl(), true, 301);
     }
 
     /**


### PR DESCRIPTION
Hey Selvin.
First off, thanks for the awesome plugin!
 
I just had a client contact me on behalf of their SEO company about their HTTPS redirect, which I'm using the Patrol secure connections for (on everything "/"). It was using a 302 redirect.

Google states for HTTPS redirects [you should use 301 redirects](https://support.google.com/webmasters/answer/6073543?hl=en).

> **Use server-side 301 redirects**
> Redirect your users and search engines to the HTTPS page or resource with server-side 301 HTTP redirects.

Having a quick look at the Craft docs for [HttpRequestService](https://craftcms.com/classreference/services/HttpRequestService), and the [Yii docs for the redirect function](http://www.yiiframework.com/doc/api/1.1/CHttpRequest#redirect-detail) it seems this can be easily changed. I've done this in this commit here.

If you're happy with the change it'd be great to roll this into the Patrol codebase :)

_P.S. I've done some testing to verify the initial requests are 302's and this modification changes them to 301s. I've had to roll this out on a couple of production sites._